### PR TITLE
check if MPI is already initialized

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,13 @@ META-INF
 classpath
 *.iml
 target
+
+\.classpath
+
+\.project
+
+\.settings/org\.eclipse\.core\.resources\.prefs
+
+\.settings/org\.eclipse\.jdt\.core\.prefs
+
+\.settings/org\.eclipse\.m2e\.core\.prefs

--- a/src/main/java/cz/it4i/scijava/mpi/MPIUtils.java
+++ b/src/main/java/cz/it4i/scijava/mpi/MPIUtils.java
@@ -36,8 +36,11 @@ public class MPIUtils {
     }
 
     private static void Init() {
-        checkMpiResult(MPILibrary.INSTANCE.MPI_Init(null, null));
-
+		int[] isInitialized = new int[1];
+		checkMpiResult(MPILibrary.INSTANCE.MPI_Initialized(isInitialized));
+		if(isInitialized[0] == 0){
+			checkMpiResult(MPILibrary.INSTANCE.MPI_Init(null, null));
+		}
         for(Field f: MPIUtils.class.getDeclaredFields()) {
             if(!f.getName().startsWith("MPI_")) {
                 continue;
@@ -157,6 +160,7 @@ public class MPIUtils {
         int MPI_Allgatherv(long sendbuf, int sendcount, Pointer sendtype,
                            long recvbuf, int[] recvcount, int[] displs, Pointer recvtype,
                            Pointer comm);
+		int MPI_Initialized(int[] flag);
         int MPI_Init(Pointer argv, Pointer argc);
         int MPI_Finalize();
         int MPI_Comm_rank(Pointer comm, int[] rank);


### PR DESCRIPTION
If scijava-parallel-mpi is used along with HPC Workflow Manager in order to use the Parallel Macro's progress logging with Jython scripts MPI  may have already been initialized by Parallel Macro. This causes an error.

Since Parallel Macro is using JNI instead of JNA if MPI is initialized with JNA first, although JNI detects that MPI is initialized it will not have initialized java variables internally and it will not provide size, rank ect. So when they are used together Parallel Macro's initialize has to be called first.