### PR TITLE
check if MPI has already been finalized

### DIFF
--- a/src/main/java/cz/it4i/scijava/mpi/MPIUtils.java
+++ b/src/main/java/cz/it4i/scijava/mpi/MPIUtils.java
@@ -36,11 +36,11 @@ public class MPIUtils {
     }
 
     private static void Init() {
-		int[] isInitialized = new int[1];
-		checkMpiResult(MPILibrary.INSTANCE.MPI_Initialized(isInitialized));
-		if(isInitialized[0] == 0){
-			checkMpiResult(MPILibrary.INSTANCE.MPI_Init(null, null));
-		}
+        int[] isInitialized = new int[1];
+        checkMpiResult(MPILibrary.INSTANCE.MPI_Initialized(isInitialized));
+        if(isInitialized[0] == 0){
+            checkMpiResult(MPILibrary.INSTANCE.MPI_Init(null, null));
+        }
         for(Field f: MPIUtils.class.getDeclaredFields()) {
             if(!f.getName().startsWith("MPI_")) {
                 continue;
@@ -55,7 +55,11 @@ public class MPIUtils {
     }
 
     public static void Finalize() {
-        MPILibrary.INSTANCE.MPI_Finalize();
+        int[] isFinalized = new int[1];
+        checkMpiResult(MPILibrary.INSTANCE.MPI_Finalized(isFinalized));
+        if(isFinalized[0] == 0) {
+            MPILibrary.INSTANCE.MPI_Finalize();
+        }
     }
 
     public static int getSize() {
@@ -160,7 +164,8 @@ public class MPIUtils {
         int MPI_Allgatherv(long sendbuf, int sendcount, Pointer sendtype,
                            long recvbuf, int[] recvcount, int[] displs, Pointer recvtype,
                            Pointer comm);
-		int MPI_Initialized(int[] flag);
+        int MPI_Initialized(int[] flag);
+        int MPI_Finalized(int[] flag);
         int MPI_Init(Pointer argv, Pointer argc);
         int MPI_Finalize();
         int MPI_Comm_rank(Pointer comm, int[] rank);


### PR DESCRIPTION
I added a check to see if MPI has already been finalized by someone else (for example ParallelMacro). 

scijava-parallel-mpi will finalize MPI only when it is not already finalized. 

I also changed the indentation of the lines I previously added to match the indentation style used by the rest of the code (4 spaces).